### PR TITLE
refactor: divide contract tests by ws, http

### DIFF
--- a/core/main/Cargo.toml
+++ b/core/main/Cargo.toml
@@ -32,7 +32,16 @@ path = "src/main.rs"
 local_dev = []
 sysd = ["sd-notify"]
 pre_prod = []
-contract_tests = []
+http_contract_tests = [
+]
+
+websocket_contract_tests = [    
+]
+
+contract_tests = [
+    "http_contract_tests",
+    "websocket_contract_tests",
+]
 tdk=[]
 [dependencies]
 base64.workspace = true

--- a/core/main/src/state/openrpc_state.rs
+++ b/core/main/src/state/openrpc_state.rs
@@ -476,7 +476,12 @@ this is only used once so far, but a bit more maintainable as a const
 /*
 test , local_dev and contract tests load the firebolt open rpc file from either a path or from the openrpc_validator version as compiled in.
 */
-#[cfg(any(feature = "local_dev", feature = "contract_tests", test))]
+#[cfg(any(
+    feature = "local_dev",
+    feature = "websocket_contract_tests",
+    feature = "http_contract_tests",
+    test
+))]
 fn load_firebolt_open_rpc_path() -> Result<String, RippleError> {
     if let Ok(path) = std::env::var("FIREBOLT_OPEN_RPC") {
         info!(
@@ -494,7 +499,12 @@ fn load_firebolt_open_rpc_path() -> Result<String, RippleError> {
 // /*
 // Production load of the firebolt open rpc file
 // */
-#[cfg(not(any(feature = "local_dev", feature = "contract_tests", test)))]
+#[cfg(not(any(
+    feature = "local_dev",
+    feature = "websocket_contract_tests",
+    feature = "http_contract_tests",
+    test
+)))]
 fn load_firebolt_open_rpc_path() -> Result<String, RippleError> {
     info!(
         "production: loading firebolt_open_rpc from file {}",

--- a/core/sdk/Cargo.toml
+++ b/core/sdk/Cargo.toml
@@ -27,9 +27,17 @@ tdk = []
 full = ["rpc"]
 sysd = []
 test = ["jsonrpsee", "mock"]
-contract_tests = []
 mock = []
+http_contract_tests = [
+]
 
+websocket_contract_tests = [
+
+]
+contract_tests = [
+    "http_contract_tests",
+    "websocket_contract_tests",
+]
 [dependencies]
 
 #dependencies inherited from workspace

--- a/core/sdk/src/api/firebolt/fb_capabilities.rs
+++ b/core/sdk/src/api/firebolt/fb_capabilities.rs
@@ -328,7 +328,10 @@ impl<'de> Deserialize<'de> for FireboltPermission {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[cfg_attr(feature = "contract_tests", derive(Serialize))]
+#[cfg_attr(
+    any(feature = "http_contract_tests", feature = "websocket_contract_tests"),
+    derive(Serialize)
+)]
 pub struct FireboltPermissions {
     pub capabilities: Vec<FireboltPermission>,
 }

--- a/device/thunder_ripple_sdk/Cargo.toml
+++ b/device/thunder_ripple_sdk/Cargo.toml
@@ -24,9 +24,8 @@ repository = "https://github.com/rdkcentral/Ripple"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-# Enable dependencies for contract tests
-contract_tests = [
-    "pact_consumer",
+http_contract_tests = [
+     "pact_consumer",
     "reqwest",
     "expectest",
     "maplit",
@@ -35,7 +34,22 @@ contract_tests = [
     "tree_magic_mini",
     "rstest",
     "futures-util"
+]
+websocket_contract_tests = [
+     "pact_consumer",
+    "reqwest",
+    "expectest",
+    "maplit",
+    "test-log",
+    "home",
+    "tree_magic_mini",
+    "rstest",
+    "futures-util"    
+]
 
+contract_tests = [
+    "http_contract_tests",
+    "websocket_contract_tests",
 ]
 local_dev=[]
 

--- a/device/thunder_ripple_sdk/src/lib.rs
+++ b/device/thunder_ripple_sdk/src/lib.rs
@@ -57,7 +57,7 @@ pub extern crate ripple_sdk;
 
 #[cfg(test)]
 pub mod tests {
-    #[cfg(feature = "contract_tests")]
+    #[cfg(feature = "websocket_contract_tests")]
     pub mod contracts {
         pub mod contract_utils;
         pub mod thunder_controller_pacts;

--- a/device/thunder_ripple_sdk/src/tests/contracts/thunder_controller_pacts.rs
+++ b/device/thunder_ripple_sdk/src/tests/contracts/thunder_controller_pacts.rs
@@ -13,7 +13,7 @@ use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::protocol::Message;
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_register_state_change_event() {
     mock_websocket_server!(
         builder,
@@ -50,7 +50,7 @@ async fn test_register_state_change_event() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_info_plugin_status() {
     mock_websocket_server!(
         builder,
@@ -97,7 +97,7 @@ async fn test_device_info_plugin_status() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_info_plugin_state() {
     mock_websocket_server!(
         builder,
@@ -133,7 +133,7 @@ async fn test_device_info_plugin_state() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_display_settings_plugin_status() {
     mock_websocket_server!(
         builder,
@@ -179,7 +179,7 @@ async fn test_display_settings_plugin_status() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_activate_display_settings_plugin() {
     mock_websocket_server!(
         builder,
@@ -215,7 +215,7 @@ async fn test_activate_display_settings_plugin() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_status_org_rdk_system() {
     mock_websocket_server!(
         builder,
@@ -261,7 +261,7 @@ async fn test_status_org_rdk_system() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_activate_org_rdk_system() {
     mock_websocket_server!(
         builder,
@@ -297,7 +297,7 @@ async fn test_activate_org_rdk_system() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_status_org_rdk_hdcp_profile() {
     mock_websocket_server!(
         builder,
@@ -343,7 +343,7 @@ async fn test_status_org_rdk_hdcp_profile() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_activate_org_rdk_hdcp_profile() {
     mock_websocket_server!(
         builder,
@@ -379,7 +379,7 @@ async fn test_activate_org_rdk_hdcp_profile() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_status_org_rdk_telemetry() {
     mock_websocket_server!(
         builder,
@@ -426,7 +426,7 @@ async fn test_status_org_rdk_telemetry() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_activate_org_rdk_telemetry() {
     mock_websocket_server!(
         builder,

--- a/device/thunder_ripple_sdk/src/tests/contracts/thunder_device_info_pacts.rs
+++ b/device/thunder_ripple_sdk/src/tests/contracts/thunder_device_info_pacts.rs
@@ -35,7 +35,7 @@ use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::protocol::Message;
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_info_mac_address() {
     // Define Pact request and response - Start
     let mut pact_builder_async = get_pact_builder_async_obj().await;
@@ -85,7 +85,7 @@ async fn test_device_get_info_mac_address() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_model() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -140,7 +140,7 @@ async fn test_device_get_model() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_interfaces_wifi() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -197,7 +197,7 @@ async fn test_device_get_interfaces_wifi() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_interfaces_ethernet() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -254,7 +254,7 @@ async fn test_device_get_interfaces_ethernet() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_audio() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -300,7 +300,7 @@ async fn test_device_get_audio() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_hdcp_supported() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -345,7 +345,7 @@ async fn test_device_get_hdcp_supported() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_hdcp_status() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -396,7 +396,7 @@ async fn test_device_get_hdcp_status() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_hdr() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -437,7 +437,7 @@ async fn test_device_get_hdr() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_screen_resolution_without_port() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -480,7 +480,7 @@ async fn test_device_get_screen_resolution_without_port() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_make() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -517,7 +517,7 @@ async fn test_device_get_make() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_video_resolution() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
     pact_builder_async
@@ -571,7 +571,7 @@ async fn test_device_get_video_resolution() {
 }
 
 // #[tokio::test(flavor = "multi_thread")]
-// #[cfg_attr(not(feature = "contract_tests"), ignore)]
+// #[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 // async fn test_device_get_system_memory() {
 //     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -622,7 +622,7 @@ async fn test_device_get_video_resolution() {
 // }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_timezone() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -670,7 +670,7 @@ async fn test_device_get_timezone() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_available_timezone() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -731,7 +731,7 @@ async fn test_device_get_available_timezone() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_voice_guidance_enabled() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -776,7 +776,7 @@ async fn test_device_get_voice_guidance_enabled() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_voice_guidance_speed() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -844,7 +844,7 @@ async fn test_device_get_voice_guidance_speed() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_set_timezone() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -894,7 +894,7 @@ async fn test_device_set_timezone() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_set_voice_guidance() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -942,7 +942,7 @@ async fn test_device_set_voice_guidance() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_set_voice_guidance_speed() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -990,7 +990,7 @@ async fn test_device_set_voice_guidance_speed() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_internet() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 

--- a/device/thunder_ripple_sdk/src/tests/contracts/thunder_package_manager_pacts.rs
+++ b/device/thunder_ripple_sdk/src/tests/contracts/thunder_package_manager_pacts.rs
@@ -44,7 +44,7 @@ const OPERATION_TIMEOUT_SECS: u64 = 12 * 60; // 12 minutes
     case(true, AppsOperationType::Uninstall, 360)
 )]
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_install_app(
     active_operations_some: bool,
     op_type_progress: AppsOperationType,
@@ -180,7 +180,7 @@ async fn test_install_app(
     case(true, AppsOperationType::Uninstall, 360)
 )]
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_uninstall_app(
     active_operations_some: bool,
     op_type_progress: AppsOperationType,
@@ -303,7 +303,7 @@ async fn test_uninstall_app(
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_get_installed_apps() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
     let installed_apps = vec![InstalledApp {
@@ -374,7 +374,7 @@ async fn test_get_installed_apps() {
 
 #[ignore]
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_init() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
 
@@ -539,7 +539,7 @@ async fn test_init() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_get_firebolt_permissions() {
     let mut pact_builder_async = get_pact_builder_async_obj().await;
     let installed_apps = vec![InstalledApp {

--- a/device/thunder_ripple_sdk/src/tests/contracts/thunder_persistent_store_pacts.rs
+++ b/device/thunder_ripple_sdk/src/tests/contracts/thunder_persistent_store_pacts.rs
@@ -32,7 +32,7 @@ use tokio_tungstenite::tungstenite::protocol::Message;
 
 #[rstest(with_scope, case(true), case(false))]
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_set_persistent_value(with_scope: bool) {
     let mut pact_builder_async = PactBuilder::new_v4("ripple", "rdk_service")
         .using_plugin("websockets", None)
@@ -115,7 +115,7 @@ async fn test_device_set_persistent_value(with_scope: bool) {
 
 #[rstest(with_scope, case(true), case(false))]
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_get_persistent_value(with_scope: bool) {
     // Define Pact request and response - Start
     let mut pact_builder_async = PactBuilder::new_v4("ripple", "rdk_service")
@@ -185,7 +185,7 @@ async fn test_device_get_persistent_value(with_scope: bool) {
 
 #[rstest(with_scope, case(true), case(false))]
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(not(feature = "contract_tests"), ignore)]
+#[cfg_attr(not(feature = "websocket_contract_tests"), ignore)]
 async fn test_device_delete_persistent_value_by_key(with_scope: bool) {
     // Define Pact request and response - Start
     let mut pact_builder_async = PactBuilder::new_v4("ripple", "rdk_service")


### PR DESCRIPTION
<!-- This is an auto-generated comment: summarize by coderabbit.ai -->
<!-- walkthrough_start -->

## Walkthrough

The changes update several Cargo.toml files to introduce two new contract test features, `http_contract_tests` and `websocket_contract_tests`, and modify the existing `contract_tests` definitions to include these. In addition, various Rust source files have been updated to adjust conditional compilation attributes. Functions and test modules now compile based on the new feature flags rather than the old `contract_tests` flag. These updates span core libraries as well as device-specific tests, enforcing more granular compile-time feature control for contract testing.

## Changes

| Files | Change Summary |
|-------|----------------|
| `core/main/Cargo.toml`, `core/sdk/Cargo.toml`, `device/.../Cargo.toml` | Added new features `http_contract_tests` and `websocket_contract_tests`; updated `contract_tests` to include these features and restructured dependency definitions. |
| `core/main/src/state/openrpc_state.rs`, `core/sdk/src/api/firebolt/fb_capabilities.rs` | Modified conditional compilation attributes to include the new test features for function compilation and trait derivation. |
| `device/thunder_ripple_sdk/src/lib.rs`, `device/thunder_ripple_sdk/src/tests/contracts/*.rs` | Updated conditional compilation in test modules, replacing `contract_tests` with `websocket_contract_tests` for test function inclusion/exclusion. |

## Sequence Diagram(s)

```mermaid
sequenceDiagram
    participant D as Developer
    participant C as Cargo Configuration
    participant R as Rust Compiler
    participant T as Test Modules

    D->>C: Introduces new features (HTTP & WebSocket contract tests)
    C-->>R: Passes updated feature flags
    R->>T: Evaluates conditional compilation attributes
    alt Feature enabled
      T-->>R: Compiles and executes tests
    else Feature disabled
      T-->>R: Ignores tests
    end
```

## Poem

> In the code's vast expanse, we set a new star,  
> Crafting features with precision—make it so, near and far.  
> HTTP and WebSocket now guide our test fleet,  
> Steering clear with refined flags, steady and neat.  
> Boldly we update, as our journey repeats.  
> Engage!  


<!-- walkthrough_end -->

<!-- announcements_start -->

> [!TIP]
> <details>
> <summary>⚡🧪 Multi-step agentic review comment chat (experimental)</summary>
> 
> - We're introducing multi-step agentic chat in review comments. This experimental feature enhances review discussions with the CodeRabbit agentic chat by enabling advanced interactions, including the ability to create pull requests directly from comments.
> 						- To enable this feature, set early_access to true under in the settings.
> 
> </details>

<!-- announcements_end -->

---

<details>
<summary>📜 Recent review details</summary>

**Configuration used: CodeRabbit UI**
**Review profile: CHILL**
**Plan: Pro**

<details>
<summary>📥 Commits</summary>

Reviewing files that changed from the base of the PR and between c0737c19b0c63e3b967bfc83290988c002df9a38 and d15f0abfffb57a128edcd3369ff892fcd6d59ecb.

</details>

<details>
<summary>📒 Files selected for processing (10)</summary>

* `core/main/Cargo.toml` (1 hunks)
* `core/main/src/state/openrpc_state.rs` (2 hunks)
* `core/sdk/Cargo.toml` (1 hunks)
* `core/sdk/src/api/firebolt/fb_capabilities.rs` (1 hunks)
* `device/thunder_ripple_sdk/Cargo.toml` (2 hunks)
* `device/thunder_ripple_sdk/src/lib.rs` (1 hunks)
* `device/thunder_ripple_sdk/src/tests/contracts/thunder_controller_pacts.rs` (11 hunks)
* `device/thunder_ripple_sdk/src/tests/contracts/thunder_device_info_pacts.rs` (20 hunks)
* `device/thunder_ripple_sdk/src/tests/contracts/thunder_package_manager_pacts.rs` (5 hunks)
* `device/thunder_ripple_sdk/src/tests/contracts/thunder_persistent_store_pacts.rs` (3 hunks)

</details>

<details>
<summary>⏰ Context from checks skipped due to timeout of 90000ms (3)</summary>

* GitHub Check: Generate Code Coverage
* GitHub Check: Run Clippy
* GitHub Check: Run Unit Tests

</details>

<details>
<summary>🔇 Additional comments (19)</summary><blockquote>

<details>
<summary>device/thunder_ripple_sdk/src/lib.rs (1)</summary>

`60-60`: **Feature flag update properly applied.**

Make it so! The change from `contract_tests` to `websocket_contract_tests` allows for more precise control over which test modules are compiled. This modification aligns perfectly with our mission to separate contract tests by protocol type.

</details>
<details>
<summary>device/thunder_ripple_sdk/src/tests/contracts/thunder_persistent_store_pacts.rs (3)</summary>

`35-35`: **Appropriate feature flag update for WebSocket tests.**

Excellent, Number One! This test function interacts with WebSocket endpoints, making the transition to the `websocket_contract_tests` feature most logical. The code structure remains unchanged while gaining more specific compilation control.

---

`118-118`: **Correct feature flag implementation for WebSocket test.**

The feature flag update is precise and appropriate. This test function, like its counterparts, communicates through WebSockets as evidenced by the use of the WebSockets plugin in the test setup and the WebSocket endpoint connections.

---

`188-188`: **Feature flag correctly applied to deletion test.**

I concur with this modification! The test's implementation clearly shows WebSocket communication patterns - the same pattern we've established in the previous tests. Engage with the new feature flag!

</details>
<details>
<summary>core/main/Cargo.toml (1)</summary>

`35-44`: **Feature flags restructured with excellent organization.**

Make it so! This modification introduces two distinct contract testing features while maintaining backward compatibility through the aggregated `contract_tests` feature. The empty arrays for the individual features allow for future expansion if specific dependencies are needed.

This structure allows us to execute:
1. Only HTTP contract tests with `http_contract_tests`
2. Only WebSocket contract tests with `websocket_contract_tests` 
3. All contract tests with the umbrella `contract_tests` feature

A most logical organization that aligns with our mission objectives.

</details>
<details>
<summary>device/thunder_ripple_sdk/src/tests/contracts/thunder_package_manager_pacts.rs (5)</summary>

`47-47`: **Feature flag correctly updated for WebSocket installation test.**

The feature flag update is appropriate for this test. The test's implementation clearly indicates WebSocket communication through the mock server configuration and connection methods. Engage with the new feature taxonomy!

---

`183-183`: **Proper feature flag applied to uninstallation test.**

Affirmative! This test function, like the installation test before it, communicates via WebSockets as indicated by the use of WebSocket connections and the WebSocket plugin in the Pact builder. The feature flag update is logical and consistent.

---

`306-306`: **Correct feature flag for app listing test.**

Indeed, this test retrieves installed applications through WebSocket communication channels. The feature flag modification maintains consistency with our new protocol-specific testing architecture. Most satisfactory!

---

`377-377`: **Appropriate feature flag for initialization test.**

I observe this test is already marked with `#[ignore]`, suggesting it may require special handling. Nevertheless, the additional WebSocket feature flag is correctly applied, as the test clearly uses WebSocket communication patterns. Make it so!

---

`542-542`: **Correct feature flag for permissions retrieval test.**

The final feature flag update maintains consistency with our established pattern. This test, like its predecessors, employs WebSocket communication protocols as evidenced by the connection methods and mock server configuration. The change is logical and appropriate.

</details>
<details>
<summary>core/sdk/Cargo.toml (1)</summary>

`31-40`: **Make it so: New contract test features added.**

Number One, these changes introduce a logical separation of contract tests into two distinct categories: HTTP and WebSocket. This is an excellent use of Rust's feature system, allowing more granular control over which types of tests are compiled and executed.

The `contract_tests` feature now serves as an umbrella that includes both specific test types, maintaining backward compatibility while providing a path forward for more targeted testing.

</details>
<details>
<summary>device/thunder_ripple_sdk/src/tests/contracts/thunder_controller_pacts.rs (2)</summary>

`16-16`: **Feature flag updated for WebSocket tests - Engage!**

The test configuration has been properly updated to use the more specific `websocket_contract_tests` feature flag instead of the generic `contract_tests`. This change aligns perfectly with the PR objective of dividing contract tests by protocol type.

---

`53-53`: **Consistent feature flag application across all test functions - Well done, Number One!**

All test functions in this file have been consistently updated to use the `websocket_contract_tests` feature flag. This demonstrates attention to detail and ensures the entire test suite responds appropriately to the new feature flags.



Also applies to: 100-100, 136-136, 182-182, 218-218, 264-264, 300-300, 346-346, 382-382, 429-429

</details>
<details>
<summary>core/sdk/src/api/firebolt/fb_capabilities.rs (1)</summary>

`331-334`: **Serialize trait derivation expanded - Make it so!**

The conditional attribute for the `FireboltPermissions` struct has been logically expanded to derive the `Serialize` trait when either HTTP or WebSocket contract tests are enabled. This maintains the serialization capability needed for testing while adapting to the new feature structure.

The syntax used for the conditional attribute is clean and follows Rust's recommended approach for complex feature conditions.

</details>
<details>
<summary>core/main/src/state/openrpc_state.rs (1)</summary>

`479-484`: **Configuration attributes properly expanded - Sensors show all systems nominal!**

The conditional compilation attributes for both implementations of `load_firebolt_open_rpc_path` have been updated to include the new `websocket_contract_tests` and `http_contract_tests` features. This ensures:

1. The development/test version is compiled when any test-related feature is enabled
2. The production version is only compiled when none of those features are active

This change maintains the intended behavior while adapting to the new feature structure. The organization of these attributes is clean and follows Rust best practices.



Also applies to: 502-507

</details>
<details>
<summary>device/thunder_ripple_sdk/Cargo.toml (2)</summary>

`27-48`: **Excellent feature refactoring for contract tests, Number One!**

I see you've separated contract tests into distinct WebSocket and HTTP features. This logical division allows for more precise control over test execution, much like how we separate the ship's systems on the Enterprise for optimal operations. The dependencies for both features appear identical - is this intentional, or might there be an opportunity to differentiate them further?

---

`50-53`: **Make it so: composite feature structure properly established.**

The restructuring of the `contract_tests` feature to include both `http_contract_tests` and `websocket_contract_tests` is a logical organization. This approach maintains backward compatibility while enabling more granular control - a wise tactical decision.

</details>
<details>
<summary>device/thunder_ripple_sdk/src/tests/contracts/thunder_device_info_pacts.rs (2)</summary>

`38-38`: **All test configurations properly adjusted to use websocket_contract_tests feature. Engage!**

You've consistently updated all test conditional compilation directives to use the new `websocket_contract_tests` feature instead of the general `contract_tests` feature. This aligns perfectly with the feature restructuring in the Cargo.toml file. The change maintains test functionality while providing more precise control over which tests are executed based on their communication protocol.



Also applies to: 88-88, 143-143, 200-200, 257-257, 303-303, 348-348, 399-399, 440-440, 483-483, 520-520, 574-574, 625-625, 673-673, 734-734, 779-779, 847-847, 897-897, 945-945, 993-993

---

`574-574`: **Acknowledged: Commented test properly updated as well.**

Even in the commented-out test function, the feature flag has been updated consistently - attention to detail worthy of a Starfleet officer. This ensures that if the test is uncommented in the future, it will follow the same configuration pattern.

</details>

</blockquote></details>

</details>
<!-- internal state start -->


<!-- DwQgtGAEAqAWCWBnSTIEMB26CuAXA9mAOYCmGJATmriQCaQDG+Ats2bgFyQAOFk+AIwBWJBrngA3EsgEBPRvlqU0AgfFwA6NPEgQAfACgjoCEYDEZyAAUASpADK2VmgqyjcEj2wAbb5AokAI7Y0riQ4rjedJAARAEAZmhi+BRctJLwSgoYuFRi4aEy8gDuiAA0kLC4uNwxkMVoyAwB1NFy4bCe2IiUkAIBGLSYglTogyjImezw8fDRjZAYTgK9AEwADPxYuJ2QAOLqABLYAv4k3PiI6iny8SmQNvDc3FEaMLu88Mwut/gM3fx4h1ULYJuF8GdEsk+DtPCQAB5IcQYIjZXJJMI0RC4IqQHrcFzUeAojokZgoHIQ3DFCHpbHE/IMVpEFJzRBcADqJAE9j+AGsSGEABSlACUY3oh1k3EoNHhYWgVAwiHivSsFHwBCYfiFVRqoo07l2SkQzSe4nwWHweG8xOkeJIUiofgF8iYzAu5ByyHwQNh1hsFQZ3mw6RJxVg1EYkZR9pcnhWxNR3yUFX9VAtGDQUT6JAQ41hPWjmFI5QlpMgbB2inw3nwRF+fC+LzJ0xJsOYb0O+GKjsoFUQMoYM3gDEgSlw2m8yACRBcYdR/rQtHSmZ9fACzHwEmzPqBTCy8cWmp4GokU3oxIrJrN3EzhoMHgD6GnELJ3EjVwAXvb/c2UpOGAMJ4voFPSKJBoMo5Eu2kaYrsDAxqWlRoFIuZkGBND0Jg9CINgRClsii5wWc54kL2FBNJgkBOjM8j+vE2BAZm2bqPIoH+lu6SzEya5vAAgiu6jwJa2beLIFRoNGoh8ra2JgsGoZ0BUEajrAlTwEQsC2lpOIVmgeCwCkADkTQsMw6hsDk4KQMErG4PI7TYjBxFRrC8iRmhPTePEYABGRvb0P6oI4egK7RFiekEJAZB4QEHRubsqrUNgATIDSFB8ugkw5GQSj0PcOxRpgtzwPCcbxSQ8SqmIkgkA+ABi9yMRQsJ8BOU5lsFdhMlgKzoAwwGID0QWwBq+Hqf6vDbhekAAKo2AAMlwADaoJmBsAC6urVNw7IAPT7UQ6iwCcGjuvt/R5cM/RoPtjzPFE+3cD43j7RsBpGPoxjgFAeWAjgBDEGQyhYQorDsFwvD8MIojiFIuIHsoqjqFoOjfSYUBwKgqDUQZQOkOQGbRO6VmcP4aDFHiTjfK4fRuooyNqJo2i6GAhg/aYBhMAE+3fMS+0AMIuCyGgEMw3gcAYMQywYFiQPxACSwNE60uE0z8AOISW0hGp42uxjlFYAAbCxQovi94xuQLMObEhItZoUuQmZgD5BU8luCpfaATeGrNlMDkeSYoUbz2EOI5Mr4EnhDSizkTFQdshUxt6twAD6gfomI6eRYg1uhcbvYCIg/KCpnlrZ7gueFMbFSeQmJAYcSuSKNgwHYcg74OegFBULIiACS7IlZtHaa7MbWfBzX2L573/coTITdYFxI4RRCilZAklBkENNmFp41IQu7mGMMyrLSG8T68I6IkAt38iT5X095wXfdoB5CwrBhAQvEk0TFBOugeOVNsQUHbl7eKRUwgYB7JAOSelU67QrkHDEM8cQF3GEXbkpcGACmrlPNBr9sooD0iQKIZNB7vFQGlXIEDUpJgpOkXicY8QIHiGEK8RkqaEPyHnXuIFzaYHgD+bC4xt4DA7vUE6V4poahEGIB85hLD8W8DQDMI9kDRX9EoBgfsNGWj3DFeEFxWrRHuC9AQtoxzTHELrAwUAAByCdPbezCvlLgSCagoKrugueV4n6835hgIWIt8BixYFbBxkBnEexICleKy4PGQGwSXMuBDn5ENrhSFJPMSB820CEs2FtInG2iQ1eJkDPBXCIFmKpkBsDcCGFhTxvDq7EICXkgpAtinhMttbQASYTHippve0XiM5tL8Zg+gqTcH4J8S/bJCxyGtm9IaGWMQvpcy6cE/aiAKAMD2ZOGg+18AygwBQbgDB07ORoBoSiUsNlyxUcrQmoNoh4WcHTUCBtSx62LIbHJciZr5XHDMIE9tHaeFXjxIkhj94IUtKuEe2ZwbcHgH7V21BcjwAEHge0dwYQTzrMudOswAgCFrNXM5ZB06XOuQSHY1tGLMRHkCieNKLlXJucc+qlFmUYvqg4COsKx4VkDsi+FTElB8FUohYEyAWW1UtGCd06Koj0AbuhLACICSDDoG8f5rJjqj2yLMIgqU4VYG6BFJKtY6yAJJBK4ShipZQGNnWKO6clASDKe6yZr9onG0imUx8nQixau/tapp/toqjNjhCJJLrTWuLSm6lJxc5nlwDbXINacFlZNnqG/iyApJpR8LgcenglWu0Ab4YZuY0WCsvFgU0ZAXAiXSp0RJGB2J+jtb4HsjDU0VThFmKxdB00er+Nmb1jo/UZpwekgtOdA3uvzTmotQaQ1GEEpK0e4kq3xznGDZ1rtCUVmmrQCBbKSUFX7Z4adpLyXcipenTldLuWMtgMypiyqsCfm1XiL4GKXDiUrIoNeQU3zwj0UpCsiA0BsAdGEUCI6qHY2QGwTAWiSIMT/bWjFfhYFU0tOB/qarm31E6FgWB5AAb+kHKIKDNtKne1LYk2qUgHwAHknRiSPb8+0ZAYzAQrPEKIiI1C2h7hxJKBGR6mSbZitlAhGjmO2LsJjw5ZjRHQ5JQdjrUQXq3PFIgSofAuDRBqPw25ej+jvYwuTngGrwApVSyAPHzkPCsILHg1B1JXm4qqAYIdwKolCj68hZyyaJ3PBqDAlClHPIVmo0GmiEWeF0foq1RjdUAXMXwSx1jE4RDZF9GJia0sGOVJl8cogctrgBvlsxBUisnBK7Ytk9Qd6VmXJ4WRCBkDBfWbLBx2yUj5MQLQPkoTzZ9MiY82W8slYq3eerL5faAV/LDfrJC9pBuPt6REiWAq7YYAdt4J2uwk2u1AifdDZxMXr2sxiTCSYw4iugmKo+IDWMJLHTi6QKcN2ZNXUsrBmbl2bowfXVCjdm5BzblI5ZHoe4uH7lQvdyaxIx39E/VB4Oi3/fqYBqNEHuJzGgxSODW8qo7yAr+Kk4bD5xwe2xtKV8Pj+Tvl3NHj8Ydz3YHTMny8zh/ykYAnYwCEEJRgXA0ZyBjYxFB4T9phQYjTJSTEKHeDs1g/V7PTXXOaGhHAWIBhJJiTMNaKWthMxOEAbgW0zCHHBFzgwCIgBMjNOeGmgoyt2RS62maYwjsDT9VEsfYL5lHP6pGGUal9RuW6vZcJE10CLWwYWI66OUrwl7FOJcXH9xk6Umq98R0rAgSpszbmyU070TYkk7cUksvszocG6mTkmvey6/Hf6eUkvNS6luMac09vMee9dOm7NgfpTIBDIJ5XwokAAC8kAVoq+QYLmIFQddLr1xktXfiYibWtp0ybfe59hJO1Ep542wBGBn3X/Zhy0Dov2i+ylaiv8CEzh/ioBigXoPA8tLMti8mtsTBtrTFtkJogP8vAeyn7meLNMFhTnROKkijjn4JRipiqtihQLivioqoVBPK5u5molYJQBZMNJotbGAhAsgSkvEP/kyASNJiAfcnPLbEKuHMxqKoeibGYCtAwPEEQOnIQUKCOuvrELvhUDKnVEKPYJQPAKxD+KKKKOfvAnaIvEBr/H7JLkAlJKZvrCwC2PCNkPup4iIWIRIVISVNISXhvtvt4vIS3vFC4brvMrvqKAoaoVIMoaoeoSQJoefibqWtVlan0BqP1rVv6GehltKr0HKpNBPCoUQSEdbOiOoGCIoVIPQBevjhQa+lQTQUgFcIYgwXQoogrHbuWmokeowfkHWsRnAvkY+hkWobaD+NbBGBhCQCdPZhPBXossTvcB3kfiuobhgh4aOonCoBqhUBmN2glFgEIN0GEP0b7rkl3sQjIagO2hOrQA+JhttllvgPaLAmEGgNVHDBWAiEiMOgpqJDJltoxjUZwjiOQkCHijcdVrhmYVBE1skbKggPKrkb1I2j0JkT0W0OpgVDsUcRqnMYPAnilqosnk1tosaA1unhlpniYgVm1l4FYnnl1oXgrNUEQX8dCpBrprQDYaIeIZIdSU4QDrITEO4R0UEbCV7mERfq2p8SkiUT/rgNQRQLQZUcqIKbsbzLPnsgcvtB/vAF/m5qUbgH/gARwcAXYqAXPEvrYSyQ4b2uyfUi4aMYWjiHvnMZyd4frifnnDEH4fVkQYEV0SEQKTks0WEMbKKVShKVKfQdPlfgqW/sqZ/t/lSlqewUATJmyNwWUg/hAE/gYD6qOPkjsKCXSk8C2Dcv3rfpbEtpsitq8iDNAdTJtlrPtggbtucUbPjvPqdjbIKhSJdtdp4LQubpAk5kCDIUoLMJ7k1r7LGhCC7nnFzoIppMSKisvmMbMTIaLhhDClTjZPGr9uzgDuyOXjvnsRDjMvacfivkWpOTuW4XucTjISRjTiGCaDLkiADEoOckoEBN1tAj1vFDfOeNaIgOBgSK1AxhPDHipAgDmPjoedMd3gccgO7OBi3BqNekYdLlJFcBZPoiho+ecHlLvAmZAEakQSarOVPouV/GLgEAOXaNTmgARLOK0BWBucXluSDruY6fuYumklMcBTFHcVxuQm6C0ERMAmqpcOoNWiXu+bvOYY0D0DIJqOpD0HpKBE+dha+ZfO8CgbfD+fVoOcmgDHOVaXPO+aMoieBsrgSDnIHJ8pQJrnoeTpuHZicXhQYHxsoL4IJjWYnKJofLsCkB7iItEWhiXspfqqpYjOfEQV+GHp0OSC3BCNppHKfA5DKGWGJEOiSCZpNpAOZpgJZnwFPLWPwE6NRmpPVs+ThfMcZX0AiVsPRdKCBPuAbq7rmIwgiKIPiiceiStlEdiczllniTVnlkSa1vwO1mSTYjkCARVhUhySPhyePmrK0hebMQEumcBPtFmZHjmY9CQPmTfvNnfoMrsaxcTteYrmeRMktXPIXBBTHoaEXnEhyW3oyedZBVXikqtZmadJtUQdtbtfXgtqdndTEoxfUk9Z4jdZdbKcbB9etV9TKltXmQqU2VbKNpso/kYDDRtfDT9Yja/kqbaAINwcWRiWWarGDJ8rAdWTrLWU+EJm2VClhvSbIFFUCfuqingdEYQcQTQDbGQdHgbnPFxD4J4FLvmCbMQkLedibJjXDZQAjVEH9eGQTYmS2a8OpTofRl+bzuBt0CzbaRJtRUdcebMUuVgAYf/PQKLexVmkefOfnBES+FiWytbtBFiHLibG0oLW3DmK0Q2hRuYVRmRiUDRibBDcdQuSXoceOksRTG1GsZejzj+eBvFQyUbXbbHgDm8I4hCHJb0CubxBljiZ4HWMdGOPcD6W4s5goIeJ+WlOwOyqgCNp1Sot1YXb1fVnovifCoSaYtnqNZ1hNXqRVoLNgSxLgQHfgdGhPs9cbEaUQGaW4i4b4doVeJLY+nnBwBwJ7VDTLdmTjQrWGfjbiirYacyfPTIV4Yfj4Zdc6SvSvN7evYUJvdvT3rvd9bmQfXjYcsrfyuAWjSmRjbfGtVjXLfvTtYfYcnnPtJ7bDdmflb4HLeZTiETX/STVAf7BTZrD8jWYgR5YdqeCCtEOgZCldt5XSZTgXSqj8qPSiuPR6KBlitSdzQSvcMwBWk8DmI0LIEBGNJaFpZFDbC8bVvg8GrLRQAsvaogxiPqWdnwV9lHEIUuEw7SSknPaybkEKNcQvZ4XITfS6ZpLAgEFodbKbeLoYd7tLrPWfeoxQJo5qNo54JfRxdfeHYgM6UGLUpNsYwNBqMNA6Pxn4AIzWpog7dmE7QQTxVFIisCUkZHsVfKgfE1UeAY5NvQNekQU6hPVagOOwoJQxH8ACPEBqOSFJG8s6Lo643UDIdFCYZlSnXngfs4w6cbW43MaecE/Cs2BiG0PRENucTefBsGqEHSiQMdNiHLbcjtUJunH2DkHXCkpFHOueMBOnMSHcOnC8PhMSDyilPnCnIsx9asxgOs5syajszQPM0M9iN6kgH/LIDcoKERIgBsyGGc7ct0Jc4sxiJIK0Dc4OH7PcwpU8y81sxgJ88M+88875XSjNjcgPDQMwOC9c98zuDQO+ubDC3yHC+M4i/sxC8ct0OixIRQLC7ALQAwBnNNLwUi9XCi789CyS1i2SxSxsxqNS3i9c5C0S5izXBQoKK4PM4XF81xvSxi4y7y62LkLIMbFnTnXHR06avAQOO3OpAsCXXnmE+lt3XwJQBqHwDGLQLaCSPnblpJLXdIPXYNo3eCsll1eE/Ee3WngNc1kNX3aSQPWVpSdnY7Vqw69eP1Snj3cSSNe6+SYPd1hRNCv1g3cNja6g+jWmUA59XvR/eA1/etYUNAwLbA5tYc2s/gBs9Iyg08qWeg+TRrN8vuDg3WUgfg9NOeKCsQxdlChWCa3dg1TE68cppzcoyQbzXwGw2ohw54Fwzwwlvw6EII6yp0zsTYJsafLwQs2I0sxmUcyc0W/yp9gId9oozdr2zzVY3YTY3Y7gA45yb4R44Y6EdoaY+bUhepIe8aWyVoxfbEGHS0+4ygJ40Y9oUkL48gDuEQRO/JAqxhn05qzVugJE4CbzYZmHpO6B54gc0m+nKQNXPm+nN8NckkmlHsws8M4c2h5h4zFbBy9XIR+XC3JQFCNIOnIArMDSyuys0R1RxQDR884KN2uQLgIxxR7S6GCJLxyh0R8yxnHhM8MSUJ8sztSJ+S2JwS3h1c+R8J+XGSxQFJ6u0R6aAELSmlLWHgCPHRydNaNXL3Rp8x+XN8AKOZzJ+XA2yQAW3pyGJmDZ6h+XOIGwF+JaCQK50R6hFOIsTtR5yQF5+QL53Z/gJp9gJkJgCs8iXQOF9XA7FFzF4zjcjKAl2R0x+A+518CF9565wpenMl8x9F0MIzoVxFyl+Vys0xpl+WEp9l25+h7lBQNxzK05WcXTSub+NE/usgKCfE2kRa0k/FCk+ReOJbqiBzZmJBDboJShbk8wTIQbaiDatTvAw8eVP8O26SEWBOerQq/ZO8bsPwh2N5AjGcMEgNzwzrLQAANxbDgYJE0Ndsze3r1h56mPzVYS2st32taKOsBsZ5AhZ6FahvjWeu1lOJVYA+p7A8Emg+uvg/FZhtQ8flRtZBWuxvVSo1bKplv3Y2puK1KlQMwMgPiPmV8jUU7XfBZikCU8bvsioOltlMYMVtwHVu014M7H1toHgr02kMYGwo9VYGduKtZOMM4q0mkF8A9ABPZTcOITjsAhBNCMNkTwU+Ft4I0+YeYA0+M9iAyOq1yPbsKN457vS/4qqPWNSEvvOEVMfv6PfvXsmOkU/znDmOW1AKPv2HPv2OvuNM22vUa7O9XveNFEDoOrwcgfq9IfDPEjOS+CSHPCMdMSJ+TjJ8f7cCMcsfKiZ8aop97SMfEjqCCtYKLNEdRlqIbPlF0FVGhOt0qou0sK4aJQjf8K+3Xn9TjcAIh3gVX3NPp22moDXELHHHLEBbDHURyKaUAiJEqpqYjQ1X47EVx6nl2bOh+AV09r0Dqtl0PoLvq9XeFIR5Ca0AqRAKwLC+u1t2khuYUjqKmrNh8s5CBtFaEhViUBokJ52u+uA/+tO6zrINsNRzxjV88Q9JvLD3/7w8gBgbJHr3RR655IeIBDHn1ix6aZrWuPeNgA0TbScc2RPX6hAwzazws2auRAAQMQbf8kQ7AHlJNm17IMwCJbSAmz3LZVlsG1NXBtTWYJ89G2AvEhmhDbZ38Xu4vdmpLzZRc0Ze/bDoDp0V5js+GqvBDnH3w7XNDmRXGUJRBoE5Biu2YEIIl1r6aDxm2gncCGB86SQK+BHFDkoCiBosNBVwIwUl10E7U5A6cV0B1yfDGoZyfgSQdb197Ht7eHJJeno0vZeMb27vM2p7wtrSJLGajO3gHwd5B9O8lTMPqEPcHgcm+WAFvrbndqJNO+RGP2gNhd6W1++E8d9sP2grHgwg8XC/rHVWJFReeidAEPpSJwR1M66tTfmJDxCfFW84wffoBUPhKDp2tWTcKfz/T7Yahdwf4FcBJAqpIoetOwVoLCAmCQg/ADQSnnwYfU0QCITQM3STwwCi6HdRrIj2MSICSSqPFAZAJh4+tnWBwp1vAJOHBswBHrVAZG3QEDZMBOPeIHj3GwcxMYice9IDEICsCSY5kSGBTFAQc96Y1dJmKjFZgYxfo4MCyOh1oDPMec5EOgDswArfQDAfw2gAAEYAArPEHWAqBqorBAkQAHY0AeI1YAAA46ADAWgAAGYmRAANgACc1UWkeyNWDxBGRrI2gASPZGiBTg2Iv4aTHUCrMURIzAKBiP+j6AgAA=== -->

<!-- internal state end -->
<!-- finishing_touch_checkbox_start -->

<details>
<summary>✨ Finishing Touches</summary>

- [ ] <!-- {"checkboxId": "7962f53c-55bc-4827-bfbf-6a18da830691"} --> 📝 Generate Docstrings

</details>

<!-- finishing_touch_checkbox_end -->
<!-- tips_start -->

---

Thanks for using CodeRabbit! It's free for OSS, and your support helps us grow. If you like it, consider giving us a shout-out.

<details>
<summary>❤️ Share</summary>

- [X](https://twitter.com/intent/tweet?text=I%20just%20used%20%40coderabbitai%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20the%20proprietary%20code.%20Check%20it%20out%3A&url=https%3A//coderabbit.ai)
- [Mastodon](https://mastodon.social/share?text=I%20just%20used%20%40coderabbitai%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20the%20proprietary%20code.%20Check%20it%20out%3A%20https%3A%2F%2Fcoderabbit.ai)
- [Reddit](https://www.reddit.com/submit?title=Great%20tool%20for%20code%20review%20-%20CodeRabbit&text=I%20just%20used%20CodeRabbit%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20proprietary%20code.%20Check%20it%20out%3A%20https%3A//coderabbit.ai)
- [LinkedIn](https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fcoderabbit.ai&mini=true&title=Great%20tool%20for%20code%20review%20-%20CodeRabbit&summary=I%20just%20used%20CodeRabbit%20for%20my%20code%20review%2C%20and%20it%27s%20fantastic%21%20It%27s%20free%20for%20OSS%20and%20offers%20a%20free%20trial%20for%20proprietary%20code)

</details>

<details>
<summary>🪧 Tips</summary>

### Chat

There are 3 ways to chat with [CodeRabbit](https://coderabbit.ai?utm_source=oss&utm_medium=github&utm_campaign=brendanobra/Ripple&utm_content=20):

- Review comments: Directly reply to a review comment made by CodeRabbit. Example:
  - `I pushed a fix in commit <commit_id>, please review it.`
  - `Generate unit testing code for this file.`
  - `Open a follow-up GitHub issue for this discussion.`
- Files and specific lines of code (under the "Files changed" tab): Tag `@coderabbitai` in a new review comment at the desired location with your query. Examples:
  - `@coderabbitai generate unit testing code for this file.`
  -	`@coderabbitai modularize this function.`
- PR comments: Tag `@coderabbitai` in a new PR comment to ask questions about the PR branch. For the best results, please provide a very specific query, as very limited context is provided in this mode. Examples:
  - `@coderabbitai gather interesting stats about this repository and render them as a table. Additionally, render a pie chart showing the language distribution in the codebase.`
  - `@coderabbitai read src/utils.ts and generate unit testing code.`
  - `@coderabbitai read the files in the src/scheduler package and generate a class diagram using mermaid and a README in the markdown format.`
  - `@coderabbitai help me debug CodeRabbit configuration file.`

Note: Be mindful of the bot's finite context window. It's strongly recommended to break down tasks such as reading entire modules into smaller chunks. For a focused discussion, use review comments to chat about specific files and their changes, instead of using the PR comments.

### CodeRabbit Commands (Invoked using PR comments)

- `@coderabbitai pause` to pause the reviews on a PR.
- `@coderabbitai resume` to resume the paused reviews.
- `@coderabbitai review` to trigger an incremental review. This is useful when automatic reviews are disabled for the repository.
- `@coderabbitai full review` to do a full review from scratch and review all the files again.
- `@coderabbitai summary` to regenerate the summary of the PR.
- `@coderabbitai generate docstrings` to [generate docstrings](https://docs.coderabbit.ai/finishing-touches/docstrings) for this PR.
- `@coderabbitai resolve` resolve all the CodeRabbit review comments.
- `@coderabbitai configuration` to show the current CodeRabbit configuration for the repository.
- `@coderabbitai help` to get help.

### Other keywords and placeholders

- Add `@coderabbitai ignore` anywhere in the PR description to prevent this PR from being reviewed.
- Add `@coderabbitai summary` to generate the high-level summary at a specific location in the PR description.
- Add `@coderabbitai` anywhere in the PR title to generate the title automatically.

### CodeRabbit Configuration File (`.coderabbit.yaml`)

- You can programmatically configure CodeRabbit by adding a `.coderabbit.yaml` file to the root of your repository.
- Please see the [configuration documentation](https://docs.coderabbit.ai/guides/configure-coderabbit) for more information.
- If your editor has YAML language server enabled, you can add the path at the top of this file to enable auto-completion and validation: `# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json`

### Documentation and Community

- Visit our [Documentation](https://docs.coderabbit.ai) for detailed information on how to use CodeRabbit.
- Join our [Discord Community](http://discord.gg/coderabbit) to get help, request features, and share feedback.
- Follow us on [X/Twitter](https://twitter.com/coderabbitai) for updates and announcements.

</details>

<!-- tips_end -->